### PR TITLE
Pre-check task does not exist

### DIFF
--- a/roles/httpd/main.yml
+++ b/roles/httpd/main.yml
@@ -1,0 +1,4 @@
+---
+- include_tasks: pre_value_check.yml
+- include_tasks: httpd_install.yml
+- include_tasks: post_check.yml

--- a/roles/httpd/post_check.yml
+++ b/roles/httpd/post_check.yml
@@ -1,0 +1,50 @@
+---
+- name: Check apache is installed
+  command:
+    cmd: "rpm -q {{ httpd_package }}"
+  changed_when: false
+  # 以下、commandモジュール実行時のエラー判定として裏で動いているものを
+  # 動作の確認をよりわかりやすくするためにあえて可視化してみました。
+  # 実際のplaybook構築時は無くても問題ありません。
+  register: _httpd_check_rpm_result
+  failed_when: _httpd_check_rpm_result.rc != 0
+  tags:
+    - skip_ansible_lint
+
+- name: Check apache is enabled
+  command:
+    cmd: "systemctl is-enabled {{ httpd_service }}"
+  changed_when: false
+  register: _httpd_check_systemd_enable_result
+  failed_when: _httpd_check_systemd_enable_result.rc != 0
+  tags:
+    - skip_ansible_lint
+
+- name: Check apache is active
+  command:
+    cmd: "systemctl is-active {{ httpd_service }}"
+  changed_when: false
+  register: _httpd_check_systemd_actvie_result
+  failed_when: _httpd_check_systemd_actvie_result.rc != 0
+  tags:
+    - skip_ansible_lint
+
+- name: Check firewalld is configured
+  command:
+    cmd: "firewall-cmd --list-ports --zone public"
+  changed_when: false
+  register: _httpd_check_firewall_result
+  failed_when: "'%d/tcp' % httpd_port not in _httpd_check_firewall_result.stdout"
+  tags:
+    - skip_ansible_lint
+
+- name: Check apache port is opened
+  wait_for:
+    timeout: 60
+    port: "{{ httpd_port }}"
+    delay: 5
+
+- name: Check http access
+  uri:
+    url: "http://{{ inventory_hostname }}:{{ httpd_port }}/"
+    status_code: 200

--- a/roles/httpd/pre_value_check.yml
+++ b/roles/httpd/pre_value_check.yml
@@ -1,0 +1,8 @@
+---
+- name: Check values of the variables should have primitive values
+  assert:
+    that:
+      - httpd_port is number
+      - httpd_port >= 1
+      - httpd_port <= 65535
+    fail_msg: "The port number must be entered as a number between 1-65535."

--- a/roles/httpd/tasks/main.yml
+++ b/roles/httpd/tasks/main.yml
@@ -1,3 +1,9 @@
 ---
-- name: Install httpd server
+- name: Include pre_value_check.yml
+  include_tasks: pre_value_check.yml
+
+- name: Include httpd_install.yml
   include_tasks: httpd_install.yml
+
+- name: Include post_check.yml
+- include_tasks: post_check.yml


### PR DESCRIPTION
-　以下のroles配下のtasksにおいて、pre-check,post-checkがない
　　- roles/httpd/tasks/
- pre-check: 実際のtaskを実行する前に、変数に指定されている値のバリデーションを実施させることで予期しない入力によるトラブルを防ぐことができる
- post-check: タスクを実行後、期待通りの結果を得られているかどうかを確認させる